### PR TITLE
Register pytest marker for isort

### DIFF
--- a/pytest_isort.py
+++ b/pytest_isort.py
@@ -11,6 +11,10 @@ __version__ = '0.1.0'
 
 MTIMES_HISTKEY = 'isort/mtimes'
 
+def pytest_configure(config):
+    config.addinivalue_line(
+        'markers',
+        "isort: Test to check import ordering")
 
 def pytest_addoption(parser):
     group = parser.getgroup('general')


### PR DESCRIPTION
This is required for compatibility with pytest --strict mode when using
pytest>=3.1 as discussed in pytest-dev/pytest#2455

