### PR TITLE
Add "py" as a dependency (#45)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ isort = "pytest_isort"
 [tool.poetry.dependencies]
 python = ">=3.6,<4"
 pytest = ">=5.0"
+py = ">1.10.0"
 importlib-metadata = {version = "*", python = "<3.8"}
 
 isort = ">=4.0"


### PR DESCRIPTION
pytest==7.2.0 dropped the dependency