### PR TITLE
fix: pytest 8.1.0 support

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 isolated_build = true
 envlist =
 	{py37,py38,py39}-{pytest5,pytest6,pytest7}-{isort4,isort5}
-	py310-{pytest6,pytest7}-{isort4,isort5}
+	{py310,py311}-{pytest6,pytest7,pytest8}-{isort4,isort5}
 
 [gh-actions]
 python =
@@ -10,6 +10,7 @@ python =
 	3.8: py38
 	3.9: py39
 	3.10: py310
+	3.11: py311
 
 [testenv]
 setenv = PYTHONPATH={toxinidir}
@@ -17,6 +18,7 @@ deps =
 	pytest5: pytest>=5,<6
 	pytest6: pytest>=6,<7
 	pytest7: pytest>=7,<8
+	pytest8: pytest>=8,<9
 	isort4: isort>=4,<5
 	isort5: isort>=5,<6
 allowlist_externals =


### PR DESCRIPTION
Implement the new `file_path` param that was introduced in pytest 7.0.0, uses `match` instead of `fnmatch` as needed under the hood.
 
* (somewhat) depends on #51
* fixes #50 